### PR TITLE
User and community registry contracts

### DIFF
--- a/packages/hardhat/contracts/Common.sol
+++ b/packages/hardhat/contracts/Common.sol
@@ -40,7 +40,6 @@ struct Community {
     string description;
     string location;
     address payable treasury;
-    FarmRecord[] farms;
 }
 
 struct ProductType {

--- a/packages/hardhat/contracts/Common.sol
+++ b/packages/hardhat/contracts/Common.sol
@@ -1,6 +1,52 @@
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+enum UserRole {
+    USER,
+    DONOR,
+    MANAGER,
+    FARMER,
+    ADMIN
+}
+
+enum TaskStatus {
+    TODO,
+    INPROGRESS,
+    COMPLETE
+}
+
+struct UserRecord {
+    address account;
+    string name;
+    string email;
+    string phone;
+    string location;
+    UserRole role;
+}
+
+struct FarmRecord {
+    string farmName;
+    address farmOwner;
+    string description;
+    string location;
+    string imageUrl;
+    string[] socialAccounts;
+    uint communityId;
+}
+
+struct Community {
+    uint id;
+    string name;
+    string description;
+    string location;
+    address treasury;
+    UserRecord[] users;
+    UserRecord[] donors;
+    UserRecord[] managers;
+    UserRecord[] farmers;
+    FarmRecord[] farms;
+}
+
 struct ProductType {
     string name;
     string unit;
@@ -15,6 +61,6 @@ struct Task {
     address creator;
     uint deadline;
     uint reward;
-    bool completed;
+    TaskStatus status;
     bytes32[] attestations;
 }

--- a/packages/hardhat/contracts/Common.sol
+++ b/packages/hardhat/contracts/Common.sol
@@ -39,11 +39,7 @@ struct Community {
     string name;
     string description;
     string location;
-    address treasury;
-    UserRecord[] users;
-    UserRecord[] donors;
-    UserRecord[] managers;
-    UserRecord[] farmers;
+    address payable treasury;
     FarmRecord[] farms;
 }
 

--- a/packages/hardhat/contracts/Common.sol
+++ b/packages/hardhat/contracts/Common.sol
@@ -1,0 +1,20 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct ProductType {
+    string name;
+    string unit;
+    string description;
+    string imageUrl;
+}
+
+struct Task {
+    uint id;
+    string name;
+    string description;
+    address creator;
+    uint deadline;
+    uint reward;
+    bool completed;
+    bytes32[] attestations;
+}

--- a/packages/hardhat/contracts/CommunityRegistry.sol
+++ b/packages/hardhat/contracts/CommunityRegistry.sol
@@ -15,6 +15,10 @@ contract CommunityRegistry is ICommunityRegistry, Ownable {
 	mapping(uint => Community) private _communitiesById;
 	mapping(string => uint) private _communityIdsByName;
 	mapping(address => uint[]) private _userToCommunityIds;
+    mapping(uint => UserRecord[]) private _communityToUsers;
+    mapping(uint => UserRecord[]) private _communityToDonors;
+    mapping(uint => UserRecord[]) private _communityToManagers;
+    mapping(uint => UserRecord[]) private _communityToFarmers;
 
 	constructor() Ownable() {}
 
@@ -148,14 +152,16 @@ contract CommunityRegistry is ICommunityRegistry, Ownable {
 		_userToCommunityIds[msg.sender].push(
 			_communitiesByName[_communityName].id
 		);
+        Community memory community = _communitiesByName[_communityName];
+        uint communityId = community.id;
 		if (_newUser.role == UserRole.USER) {
-			_communitiesByName[_communityName].users.push(_newUser);
+			_communityToUsers[communityId].push(_newUser);
 		} else if (_newUser.role == UserRole.DONOR) {
-			_communitiesByName[_communityName].donors.push(_newUser);
+			_communityToDonors[communityId].push(_newUser);
 		} else if (_newUser.role == UserRole.MANAGER) {
-			_communitiesByName[_communityName].managers.push(_newUser);
+			_communityToManagers[communityId].push(_newUser);
 		} else if (_newUser.role == UserRole.FARMER) {
-			_communitiesByName[_communityName].farmers.push(_newUser);
+			_communityToFarmers[communityId].push(_newUser);
 		} else {
 			revert("Invalid role");
 		}
@@ -166,42 +172,35 @@ contract CommunityRegistry is ICommunityRegistry, Ownable {
 		UserRole _role,
 		uint256 index
     ) internal returns (address userToRemove) {
+        uint communityId = _communitiesByName[_communityName].id;
         if (_role == UserRole.USER) {
 			require(
-				_communitiesByName[_communityName].users.length > index,
+				_communityToUsers[communityId].length > index,
 				"Index out of bounds"
 			);
-			userToRemove = _communitiesByName[_communityName]
-				.users[index]
-				.account;
-			delete _communitiesByName[_communityName].users[index];
+			userToRemove = _communityToUsers[communityId][index].account;
+			delete _communityToUsers[communityId][index];
 		} else if (_role == UserRole.DONOR) {
 			require(
-				_communitiesByName[_communityName].donors.length > index,
+				_communityToDonors[communityId].length > index,
 				"Index out of bounds"
 			);
-			userToRemove = _communitiesByName[_communityName]
-				.donors[index]
-				.account;
-			delete _communitiesByName[_communityName].donors[index];
+			userToRemove = _communityToDonors[communityId][index].account;
+			delete _communityToDonors[communityId][index];
 		} else if (_role == UserRole.FARMER) {
 			require(
-				_communitiesByName[_communityName].farmers.length > index,
+				_communityToFarmers[communityId].length > index,
 				"Index out of bounds"
 			);
-			userToRemove = _communitiesByName[_communityName]
-				.farmers[index]
-				.account;
-			delete _communitiesByName[_communityName].farmers[index];
+			userToRemove = _communityToFarmers[communityId][index].account;
+			delete _communityToFarmers[communityId][index];
 		} else if (_role == UserRole.MANAGER) {
 			require(
-				_communitiesByName[_communityName].managers.length > index,
+				_communityToManagers[communityId].length > index,
 				"Index out of bounds"
 			);
-			userToRemove = _communitiesByName[_communityName]
-				.managers[index]
-				.account;
-			delete _communitiesByName[_communityName].managers[index];
+			userToRemove = _communityToManagers[communityId][index].account;
+			delete _communityToManagers[communityId][index];
 		} else {
 			revert("Invalid role");
 		}

--- a/packages/hardhat/contracts/CommunityRegistry.sol
+++ b/packages/hardhat/contracts/CommunityRegistry.sol
@@ -151,6 +151,17 @@ contract CommunityRegistry is ICommunityRegistry, Ownable {
 		_communitiesById[communityId] = newCommunity;
 		_communityIdsByName[_name] = communityId;
 		communities.push(newCommunity);
+        for (uint i = 0; i < _initialOwners.length; i++) {
+			UserRecord memory user = userRegistry.userRecordByAddress(
+				_initialOwners[i]
+			);
+			require(user.account != address(0), "User does not exist");
+			require(
+				user.role != UserRole.USER && user.role != UserRole.DONOR,
+				"Initial owners must be admins, farmers or managers"
+			);
+            _addUserToCommunity(user, communityId);
+		}
 		emit CommunityRegistered(_name, _location, msg.sender, newTreasury);
 	}
 

--- a/packages/hardhat/contracts/CommunityRegistry.sol
+++ b/packages/hardhat/contracts/CommunityRegistry.sol
@@ -1,0 +1,216 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "./interfaces/ICommunityRegistry.sol";
+import "./interfaces/IUserRegistry.sol";
+
+contract CommunityRegistry is ICommunityRegistry, Ownable {
+	IUserRegistry public userRegistry;
+
+	// Community mappings
+	Community[] public communities;
+	mapping(string => Community) private _communitiesByName;
+	mapping(uint => Community) private _communitiesById;
+	mapping(string => uint) private _communityIdsByName;
+	mapping(address => uint[]) private _userToCommunityIds;
+
+	constructor() Ownable() {}
+
+	// External view functions
+
+	function communitiesByName(
+		string memory _name
+	) external view override returns (Community memory) {
+		return _communitiesByName[_name];
+	}
+
+	function communitiesById(
+		uint _id
+	) external view override returns (Community memory) {
+		return _communitiesById[_id];
+	}
+
+    function communityIdByName(
+		string memory _name
+	) external view override returns (uint) {
+        return _communityIdsByName[_name];
+    }
+
+	function userToCommunityIds(
+		address _user
+	) external view override returns (uint[] memory) {
+        return _userToCommunityIds[_user];
+    }
+
+	// External registration functions
+
+	function addUserToCommunity(
+		address _newMember,
+		string memory _communityName
+	) external {
+		require(_newMember != address(0), "Invalid address");
+		require(
+			userRegistry.userRecordByAddress(_newMember).account != address(0),
+			"User is not registered"
+		);
+		require(
+			bytes(_communityName).length > 0,
+			"Community name cannot be empty"
+		);
+		require(
+			_communitiesByName[_communityName].treasury != address(0),
+			"Community does not exist"
+		);
+		if (_userToCommunityIds[_newMember].length > 0) {
+			for (uint i; i < _userToCommunityIds[_newMember].length; ++i) {
+				require(
+					!Strings.equal(
+						communities[_userToCommunityIds[_newMember][i]].name,
+						_communityName
+					),
+					"User already in community"
+				);
+			}
+		}
+		UserRecord memory newMember = userRegistry.userRecordByAddress(
+			_newMember
+		);
+		if (
+			newMember.role != UserRole.USER && newMember.role != UserRole.DONOR
+		) {
+			require(
+				msg.sender != newMember.account,
+				"Farmers, managers and admins cannot add themselves"
+			);
+			UserRecord memory senderUser = userRegistry.userRecordByAddress(
+				msg.sender
+			);
+			require(
+				senderUser.role != UserRole.USER &&
+					senderUser.role != UserRole.DONOR,
+				"Only farmers, managers and admins can add other farmers, managers and admins"
+			);
+		}
+		_addUserToCommunity(newMember, _communityName);
+		emit UserJoinedCommunity(
+			newMember.account,
+			_communityName,
+			newMember.role
+		);
+	}
+
+	function removeUserFromCommunity(
+		string memory _communityName,
+		UserRole _role,
+		uint256 index
+	) external {
+		require(
+			bytes(_communityName).length > 0,
+			"Community name cannot be empty"
+		);
+		require(
+			_communitiesByName[_communityName].treasury != address(0),
+			"Community does not exist"
+		);
+		UserRecord memory senderUser = userRegistry.userRecordByAddress(
+			msg.sender
+		);
+		require(
+			senderUser.role == UserRole.ADMIN,
+			"Only admins can remove users from a community"
+		);
+		require(
+			_role != UserRole.ADMIN,
+			"Admins cannot be removed from a community"
+		);
+		address userToRemove = _removeUserFromCommunity(_communityName, _role, index);
+		emit UserRemovedFromCommunity(userToRemove, _communityName);
+	}
+
+	// External admin functions
+
+	function setUserRegistry(address _userRegistry) external onlyOwner {
+		userRegistry = IUserRegistry(_userRegistry);
+	}
+
+	// Internal functions
+
+	function _addUserToCommunity(
+		UserRecord memory _newUser,
+		string memory _communityName
+	) internal {
+		require(
+			_communitiesByName[_communityName].treasury != address(0),
+			"Community does not exist"
+		);
+		_userToCommunityIds[msg.sender].push(
+			_communitiesByName[_communityName].id
+		);
+		if (_newUser.role == UserRole.USER) {
+			_communitiesByName[_communityName].users.push(_newUser);
+		} else if (_newUser.role == UserRole.DONOR) {
+			_communitiesByName[_communityName].donors.push(_newUser);
+		} else if (_newUser.role == UserRole.MANAGER) {
+			_communitiesByName[_communityName].managers.push(_newUser);
+		} else if (_newUser.role == UserRole.FARMER) {
+			_communitiesByName[_communityName].farmers.push(_newUser);
+		} else {
+			revert("Invalid role");
+		}
+	}
+
+    function _removeUserFromCommunity(
+        string memory _communityName,
+		UserRole _role,
+		uint256 index
+    ) internal returns (address userToRemove) {
+        if (_role == UserRole.USER) {
+			require(
+				_communitiesByName[_communityName].users.length > index,
+				"Index out of bounds"
+			);
+			userToRemove = _communitiesByName[_communityName]
+				.users[index]
+				.account;
+			delete _communitiesByName[_communityName].users[index];
+		} else if (_role == UserRole.DONOR) {
+			require(
+				_communitiesByName[_communityName].donors.length > index,
+				"Index out of bounds"
+			);
+			userToRemove = _communitiesByName[_communityName]
+				.donors[index]
+				.account;
+			delete _communitiesByName[_communityName].donors[index];
+		} else if (_role == UserRole.FARMER) {
+			require(
+				_communitiesByName[_communityName].farmers.length > index,
+				"Index out of bounds"
+			);
+			userToRemove = _communitiesByName[_communityName]
+				.farmers[index]
+				.account;
+			delete _communitiesByName[_communityName].farmers[index];
+		} else if (_role == UserRole.MANAGER) {
+			require(
+				_communitiesByName[_communityName].managers.length > index,
+				"Index out of bounds"
+			);
+			userToRemove = _communitiesByName[_communityName]
+				.managers[index]
+				.account;
+			delete _communitiesByName[_communityName].managers[index];
+		} else {
+			revert("Invalid role");
+		}
+		uint[] memory userCommunities = _userToCommunityIds[userToRemove];
+		for (uint i; i < userCommunities.length; ++i) {
+			if (userCommunities[i] == _communityIdsByName[_communityName]) {
+				delete _userToCommunityIds[userToRemove][i];
+				break;
+			}
+		}
+    }
+}

--- a/packages/hardhat/contracts/SafeImports.sol
+++ b/packages/hardhat/contracts/SafeImports.sol
@@ -1,0 +1,5 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@safe-global/safe-contracts/contracts/Safe.sol";
+import "@safe-global/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";

--- a/packages/hardhat/contracts/UserRegistry.sol
+++ b/packages/hardhat/contracts/UserRegistry.sol
@@ -1,0 +1,194 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "./interfaces/IUserRegistry.sol";
+
+contract UserRegistry is IUserRegistry, Ownable {
+
+    // UserRecord mappings
+    mapping(address => UserRecord) public userRecordsByAddress;
+    mapping(string => UserRecord) public userRecordsByEmail;
+
+    // FarmRecord mappings
+    mapping(address => FarmRecord) public farmRecordsByOwner;
+    mapping(string => FarmRecord) public farmRecordsByName;
+    mapping(address => ProductType[]) public farmProductsByOwner;
+
+    // Attestation mappings
+    mapping(address => bytes32[]) public attestationsSentByUser;
+    mapping(address => bytes32[]) public attestationsReceivedByUser;
+
+    modifier onlyUserAccount() {
+        UserRecord memory user = userRecordsByAddress[msg.sender];
+        require(msg.sender == user.account, "Not authorized user account");
+        _;
+    }
+
+    modifier onlyFarmOwner() {
+        FarmRecord memory farm = farmRecordsByOwner[msg.sender];
+        require(msg.sender == farm.farmOwner, "Not authorized farm owner");
+        _;
+    }
+
+    constructor() Ownable() {}
+
+    // External functions
+
+    /// External registration functions
+
+    function registerUserSelf(
+        string memory _name, 
+        string memory _email,
+        string memory _phone,
+        string memory _location,
+        UserRole _role
+    ) external returns (bool) {
+        require(bytes(_email).length > 0, "Email cannot be empty");
+        require(bytes(_name).length > 0, "Name cannot be empty");
+        require(
+            msg.sender == owner() || (_role != UserRole.ADMIN && _role != UserRole.MANAGER), 
+            "Only owner can register admin and manager roles"
+        );
+        require(userRecordsByAddress[msg.sender].account == address(0), "User address already registered");
+        require(userRecordsByEmail[_email].account == address(0), "Email already registered");
+        UserRecord memory newUser = UserRecord({
+            account: msg.sender,
+            name: _name,
+            email: _email,
+            phone: _phone,
+            location: _location,
+            role: _role
+        });
+        _registerUser(newUser);
+        emit UserRegistered(newUser.account, newUser.email, newUser.role);
+        return true;
+    }
+
+    function registerUserOnBehalfOf(
+        address _userAddress,
+        string memory _name,
+        string memory _email,
+        string memory _phone,
+        string memory _location,
+        UserRole _role
+    ) external returns (bool) {
+        require(bytes(_email).length > 0, "Email cannot be empty");
+        require(bytes(_name).length > 0, "Name cannot be empty");
+        require(
+            msg.sender == owner() || (_role != UserRole.ADMIN), 
+            "Only owner can register admin role"
+        );
+        require(userRecordsByAddress[_userAddress].account == address(0), "User address already registered");
+        require(userRecordsByEmail[_email].account == address(0), "Email already registered");
+        UserRecord memory senderUser = userRecordsByAddress[msg.sender];
+        require(
+            senderUser.role == UserRole.ADMIN || senderUser.role == UserRole.FARMER || senderUser.role == UserRole.MANAGER, 
+            "Only admins, farmers and managers can register users on their behalf"
+        );
+        UserRecord memory newUser = UserRecord({
+            account: _userAddress,
+            name: _name,
+            email: _email,
+            phone: _phone,
+            location: _location,
+            role: _role
+        });
+        _registerUser(newUser);
+        emit UserRegistered(newUser.account, newUser.email, newUser.role);
+        return true;
+    }
+
+    function registerFarm(
+        address _farmOwner,
+        string memory _farmName,
+        string memory _description,
+        string memory _location,
+        string memory _imageUrl,
+        string[] memory _socialAccounts
+    ) external returns (bool) {
+        require(bytes(_farmName).length > 0, "Farm name cannot be empty");
+        require(userRecordsByAddress[_farmOwner].account != address(0), "Farm owner is not a registered user");
+        require(userRecordsByAddress[_farmOwner].role == UserRole.FARMER, "Only farmers can register as farm owners");
+        require(farmRecordsByOwner[_farmOwner].farmOwner == address(0), "Farm owner already has a registered farm");
+        require(farmRecordsByName[_farmName].farmOwner == address(0), "Farm name already exists");
+        UserRecord memory senderUser = userRecordsByAddress[msg.sender];
+        require(msg.sender == _farmOwner || senderUser.role == UserRole.ADMIN, "Only farm owner and admins can register farms");
+        FarmRecord memory newFarm = FarmRecord({
+            farmName: _farmName,
+            farmOwner: _farmOwner,
+            description: _description,
+            location: _location,
+            imageUrl: _imageUrl,
+            socialAccounts: _socialAccounts
+        });
+        _registerFarm(newFarm);
+        return true;
+    }
+
+    /// External registry management functions
+
+    function updateUserRecord(
+        string memory _newName,
+        string memory _newEmail,
+        string memory _newPhone,
+        string memory _newLocation
+    ) external onlyUserAccount returns (UserRecord memory) {
+        require(bytes(_newName).length > 0, "Name cannot be empty");
+        require(bytes(_newEmail).length > 0, "Email cannot be empty");
+        UserRecord storage userRecord = userRecordsByAddress[msg.sender];
+        string memory oldEmail = userRecord.email;
+        userRecord.name = _newName;
+        userRecord.email = _newEmail;
+        userRecord.phone = _newPhone;
+        userRecord.location = _newLocation;
+        if(!Strings.equal(oldEmail, _newEmail)) {
+            require(userRecordsByEmail[_newEmail].account == address(0), "New email already registered");
+            delete userRecordsByEmail[oldEmail];
+            userRecordsByEmail[_newEmail] = userRecord;
+        }
+        return userRecord;
+    }
+
+    function updateFarmRecord(
+        string memory _newDescription,
+        string memory _newLocation,
+        string memory _newImageUrl,
+        string[] memory _newSocialAccounts
+    ) external onlyFarmOwner returns (FarmRecord memory) {
+        FarmRecord storage farmRecord = farmRecordsByOwner[msg.sender];
+        farmRecord.description = _newDescription;
+        farmRecord.location = _newLocation;
+        farmRecord.imageUrl = _newImageUrl;
+        farmRecord.socialAccounts = _newSocialAccounts;
+        return farmRecord;
+    }
+
+    function addFarmProducts(ProductType[] memory _products) external onlyFarmOwner {
+        ProductType[] storage products = farmProductsByOwner[msg.sender];
+        for (uint i = 0; i < _products.length; ++i) {
+            require(bytes(_products[i].name).length > 0, "Product name cannot be empty");
+            require(bytes(_products[i].unit).length > 0, "Product unit cannot be empty");
+            products.push(_products[i]);
+        }
+    }
+
+    function removeFarmProduct(uint index) external onlyFarmOwner {
+        ProductType[] storage products = farmProductsByOwner[msg.sender];
+        require(index < products.length, "Index out of bounds");
+        delete products[index];
+    }
+
+    // Internal functions
+
+    function _registerUser(UserRecord memory _userRecord) internal {
+        userRecordsByAddress[_userRecord.account] = _userRecord;
+        userRecordsByEmail[_userRecord.email] = _userRecord;
+    }
+
+    function _registerFarm(FarmRecord memory _farmRecord) internal {
+        farmRecordsByOwner[_farmRecord.farmOwner] = _farmRecord;
+        farmRecordsByName[_farmRecord.farmName] = _farmRecord;
+    }        
+}

--- a/packages/hardhat/contracts/UserRegistry.sol
+++ b/packages/hardhat/contracts/UserRegistry.sol
@@ -219,15 +219,6 @@ contract UserRegistry is IUserRegistry, Ownable {
 		return true;
 	}
 
-	// function registerCommunity(
-	//     string memory _name,
-	//     string memory _description,
-	//     string memory _location,
-	//     FarmRecord[] memory _farms
-	// ) external returns (address newTreasury) {
-
-	// }
-
 	// External registry management functions
 
 	function updateUserRecord(

--- a/packages/hardhat/contracts/UserRegistry.sol
+++ b/packages/hardhat/contracts/UserRegistry.sol
@@ -17,7 +17,6 @@ contract UserRegistry is IUserRegistry, Ownable {
 	// FarmRecord mappings
 	mapping(address => FarmRecord) private _farmRecordsByOwner;
 	mapping(string => FarmRecord) private _farmRecordsByName;
-	mapping(address => ProductType[]) private _farmProductsByOwner;
 
 	// Attestation mappings
 	mapping(address => bytes32[]) private _attestationsSentByUser;
@@ -258,29 +257,6 @@ contract UserRegistry is IUserRegistry, Ownable {
 		farmRecord.imageUrl = _newImageUrl;
 		farmRecord.socialAccounts = _newSocialAccounts;
 		return farmRecord;
-	}
-
-	function addFarmProducts(
-		ProductType[] memory _products
-	) external onlyFarmOwner {
-		ProductType[] storage products = _farmProductsByOwner[msg.sender];
-		for (uint i; i < _products.length; ++i) {
-			require(
-				bytes(_products[i].name).length > 0,
-				"Product name cannot be empty"
-			);
-			require(
-				bytes(_products[i].unit).length > 0,
-				"Product unit cannot be empty"
-			);
-			products.push(_products[i]);
-		}
-	}
-
-	function removeFarmProduct(uint index) external onlyFarmOwner {
-		ProductType[] storage products = _farmProductsByOwner[msg.sender];
-		require(index < products.length, "Index out of bounds");
-		delete products[index];
 	}
 
 	// External admin functions

--- a/packages/hardhat/contracts/UserRegistry.sol
+++ b/packages/hardhat/contracts/UserRegistry.sol
@@ -4,259 +4,313 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "./interfaces/IUserRegistry.sol";
+import "./interfaces/ICommunityRegistry.sol";
 
 contract UserRegistry is IUserRegistry, Ownable {
+	ICommunityRegistry public communityRegistry;
+	UserRecord[] public admins;
 
-    // UserRecord mappings
-    mapping(address => UserRecord) public userRecordsByAddress;
-    mapping(string => UserRecord) public userRecordsByEmail;
+	// UserRecord mappings
+	mapping(address => UserRecord) private _userRecordsByAddress;
+	mapping(string => UserRecord) private _userRecordsByEmail;
 
-    // FarmRecord mappings
-    mapping(address => FarmRecord) public farmRecordsByOwner;
-    mapping(string => FarmRecord) public farmRecordsByName;
-    mapping(address => ProductType[]) public farmProductsByOwner;
+	// FarmRecord mappings
+	mapping(address => FarmRecord) private _farmRecordsByOwner;
+	mapping(string => FarmRecord) private _farmRecordsByName;
+	mapping(address => ProductType[]) private _farmProductsByOwner;
 
-    // Community mappings
-    Community[] public communities;
-    mapping(string => Community) public communitiesByName;
-    mapping(uint => Community) public communitiesById;
-    mapping(string => uint) public communityIdsByName;
-    mapping(address => uint[]) public userToCommunityIds;
+	// Attestation mappings
+	mapping(address => bytes32[]) private _attestationsSentByUser;
+	mapping(address => bytes32[]) private _attestationsReceivedByUser;
 
-    // Attestation mappings
-    mapping(address => bytes32[]) public attestationsSentByUser;
-    mapping(address => bytes32[]) public attestationsReceivedByUser;
+	modifier onlyUserAccount() {
+		UserRecord memory user = _userRecordsByAddress[msg.sender];
+		require(msg.sender == user.account, "Not authorized user account");
+		_;
+	}
 
-    modifier onlyUserAccount() {
-        UserRecord memory user = userRecordsByAddress[msg.sender];
-        require(msg.sender == user.account, "Not authorized user account");
-        _;
+	modifier onlyFarmOwner() {
+		FarmRecord memory farm = _farmRecordsByOwner[msg.sender];
+		require(msg.sender == farm.farmOwner, "Not authorized farm owner");
+		_;
+	}
+
+	constructor() Ownable() {}
+
+	// External view functions
+
+    function userRecordByAddress(
+		address _address
+	) external view override returns (UserRecord memory) {
+        return _userRecordsByAddress[_address];
     }
 
-    modifier onlyFarmOwner() {
-        FarmRecord memory farm = farmRecordsByOwner[msg.sender];
-        require(msg.sender == farm.farmOwner, "Not authorized farm owner");
-        _;
+	function userRecordByEmail(
+		string memory _email
+	) external view override returns (UserRecord memory) {
+        return _userRecordsByEmail[_email];
     }
 
-    constructor() Ownable() {}
-
-    // External functions
-
-    /// External registration functions
-
-    function registerUserSelf(
-        string memory _name, 
-        string memory _email,
-        string memory _phone,
-        string memory _location,
-        UserRole _role,
-        string memory _communityName
-    ) external returns (bool) {
-        require(bytes(_email).length > 0, "Email cannot be empty");
-        require(bytes(_name).length > 0, "Name cannot be empty");
-        require(
-            msg.sender == owner() || (_role != UserRole.ADMIN && _role != UserRole.MANAGER), 
-            "Only owner can register admin and manager roles"
-        );
-        require(userRecordsByAddress[msg.sender].account == address(0), "User address already registered");
-        require(userRecordsByEmail[_email].account == address(0), "Email already registered");
-        UserRecord memory newUser = UserRecord({
-            account: msg.sender,
-            name: _name,
-            email: _email,
-            phone: _phone,
-            location: _location,
-            role: _role
-        });
-        _registerUser(newUser);
-        emit UserRegistered(newUser.account, newUser.email, newUser.role);
-        if(bytes(_communityName).length > 0) {
-            _addUserToCommunity(newUser, _communityName);
-            emit UserJoinedCommunity(newUser.account, _communityName, newUser.role);
-        }
-        return true;
+	function farmRecordByOwner(
+		address _owner
+	) external view override returns (FarmRecord memory) {
+        return _farmRecordsByOwner[_owner];
     }
 
-    function registerUserOnBehalfOf(
-        address _userAddress,
-        string memory _name,
-        string memory _email,
-        string memory _phone,
-        string memory _location,
-        UserRole _role,
-        string memory _communityName
-    ) external returns (bool) {
-        require(bytes(_email).length > 0, "Email cannot be empty");
-        require(bytes(_name).length > 0, "Name cannot be empty");
-        require(userRecordsByAddress[_userAddress].account == address(0), "User address already registered");
-        require(userRecordsByEmail[_email].account == address(0), "Email already registered");
-        UserRecord memory senderUser = userRecordsByAddress[msg.sender];
-        require(senderUser.account != address(0), "Only registered users can register others");
-        require(
-            (_role != UserRole.ADMIN) || msg.sender == owner() || senderUser.role == UserRole.ADMIN, 
-            "Only owner and other admins can register new admins"
-        );
-        require(
-            senderUser.role == UserRole.ADMIN || senderUser.role == UserRole.FARMER || senderUser.role == UserRole.MANAGER, 
-            "Only admins, farmers and managers can register users on their behalf"
-        );
-        UserRecord memory newUser = UserRecord({
-            account: _userAddress,
-            name: _name,
-            email: _email,
-            phone: _phone,
-            location: _location,
-            role: _role
-        });
-        _registerUser(newUser);
-        emit UserRegistered(newUser.account, newUser.email, newUser.role);
-        if(bytes(_communityName).length > 0) {
-            _addUserToCommunity(newUser, _communityName);
-            emit UserJoinedCommunity(newUser.account, _communityName, newUser.role);
-        }
-        return true;
+	function farmRecordByName(
+		string memory _name
+	) external view override returns (FarmRecord memory) {
+        return _farmRecordsByName[_name];
     }
 
-    function registerFarm(
-        address _farmOwner,
-        string memory _farmName,
-        string memory _description,
-        string memory _location,
-        string memory _imageUrl,
-        string[] memory _socialAccounts,
-        string memory _communityName
-    ) external returns (bool) {
-        require(bytes(_farmName).length > 0, "Farm name cannot be empty");
-        require(bytes(_communityName).length > 0, "Community name cannot be empty");
-        require(userRecordsByAddress[_farmOwner].account != address(0), "Farm owner is not a registered user");
-        require(userRecordsByAddress[_farmOwner].role == UserRole.FARMER, "Only farmers can register as farm owners");
-        require(farmRecordsByOwner[_farmOwner].farmOwner == address(0), "Farm owner already has a registered farm");
-        require(farmRecordsByName[_farmName].farmOwner == address(0), "Farm name already exists");
-        require(communitiesByName[_communityName].treasury != address(0), "Community does not exist");
-        UserRecord memory senderUser = userRecordsByAddress[msg.sender];
-        require(msg.sender == _farmOwner || senderUser.role == UserRole.ADMIN, "Only farm owner and admins can register farms");
-        FarmRecord memory newFarm = FarmRecord({
-            farmName: _farmName,
-            farmOwner: _farmOwner,
-            description: _description,
-            location: _location,
-            imageUrl: _imageUrl,
-            socialAccounts: _socialAccounts,
-            communityId: communitiesByName[_communityName].id
-        });
-        _registerFarm(newFarm);
-        emit FarmRegistered(_farmName, _farmOwner, communitiesByName[_communityName].id);
-        return true;
-    }
+	// External registration functions
 
-    /// External registry management functions
+	function registerUserSelf(
+		string memory _name,
+		string memory _email,
+		string memory _phone,
+		string memory _location,
+		UserRole _role,
+		string memory _communityName
+	) external returns (bool) {
+		require(bytes(_email).length > 0, "Email cannot be empty");
+		require(bytes(_name).length > 0, "Name cannot be empty");
+		require(
+			msg.sender == owner() ||
+				(_role != UserRole.ADMIN && _role != UserRole.MANAGER),
+			"Only owner can register admin and manager roles"
+		);
+		require(
+			_userRecordsByAddress[msg.sender].account == address(0),
+			"User address already registered"
+		);
+		require(
+			_userRecordsByEmail[_email].account == address(0),
+			"Email already registered"
+		);
+		UserRecord memory newUser = UserRecord({
+			account: msg.sender,
+			name: _name,
+			email: _email,
+			phone: _phone,
+			location: _location,
+			role: _role
+		});
+		_registerUser(newUser);
+		if (_role == UserRole.ADMIN) {
+			admins.push(newUser);
+		}
+		emit UserRegistered(newUser.account, newUser.email, newUser.role);
+		if(bytes(_communityName).length > 0) {
+		    communityRegistry.addUserToCommunity(newUser.account, _communityName);
+		}
+		return true;
+	}
 
-    function updateUserRecord(
-        string memory _newName,
-        string memory _newEmail,
-        string memory _newPhone,
-        string memory _newLocation
-    ) external onlyUserAccount returns (UserRecord memory) {
-        require(bytes(_newName).length > 0, "Name cannot be empty");
-        require(bytes(_newEmail).length > 0, "Email cannot be empty");
-        UserRecord storage userRecord = userRecordsByAddress[msg.sender];
-        string memory oldEmail = userRecord.email;
-        userRecord.name = _newName;
-        userRecord.email = _newEmail;
-        userRecord.phone = _newPhone;
-        userRecord.location = _newLocation;
-        if(!Strings.equal(oldEmail, _newEmail)) {
-            require(userRecordsByEmail[_newEmail].account == address(0), "New email already registered");
-            delete userRecordsByEmail[oldEmail];
-            userRecordsByEmail[_newEmail] = userRecord;
-        }
-        return userRecord;
-    }
+	function registerUserOnBehalfOf(
+		address _userAddress,
+		string memory _name,
+		string memory _email,
+		string memory _phone,
+		string memory _location,
+		UserRole _role,
+		string memory _communityName
+	) external returns (bool) {
+		require(bytes(_email).length > 0, "Email cannot be empty");
+		require(bytes(_name).length > 0, "Name cannot be empty");
+		require(
+			_userRecordsByAddress[_userAddress].account == address(0),
+			"User address already registered"
+		);
+		require(
+			_userRecordsByEmail[_email].account == address(0),
+			"Email already registered"
+		);
+		UserRecord memory senderUser = _userRecordsByAddress[msg.sender];
+		require(
+			senderUser.account != address(0),
+			"Only registered users can register others"
+		);
+		require(
+			(_role != UserRole.ADMIN) ||
+				msg.sender == owner() ||
+				senderUser.role == UserRole.ADMIN,
+			"Only owner and other admins can register new admins"
+		);
+		require(
+			senderUser.role == UserRole.ADMIN ||
+				senderUser.role == UserRole.FARMER ||
+				senderUser.role == UserRole.MANAGER,
+			"Only admins, farmers and managers can register users on their behalf"
+		);
+		UserRecord memory newUser = UserRecord({
+			account: _userAddress,
+			name: _name,
+			email: _email,
+			phone: _phone,
+			location: _location,
+			role: _role
+		});
+		_registerUser(newUser);
+		emit UserRegistered(newUser.account, newUser.email, newUser.role);
+		if(bytes(_communityName).length > 0) {
+		    communityRegistry.addUserToCommunity(newUser.account, _communityName);
+		}
+		return true;
+	}
 
-    function updateFarmRecord(
-        string memory _newDescription,
-        string memory _newLocation,
-        string memory _newImageUrl,
-        string[] memory _newSocialAccounts
-    ) external onlyFarmOwner returns (FarmRecord memory) {
-        FarmRecord storage farmRecord = farmRecordsByOwner[msg.sender];
-        farmRecord.description = _newDescription;
-        farmRecord.location = _newLocation;
-        farmRecord.imageUrl = _newImageUrl;
-        farmRecord.socialAccounts = _newSocialAccounts;
-        return farmRecord;
-    }
+	function registerFarm(
+		address _farmOwner,
+		string memory _farmName,
+		string memory _description,
+		string memory _location,
+		string memory _imageUrl,
+		string[] memory _socialAccounts,
+		string memory _communityName
+	) external returns (bool) {
+		require(bytes(_farmName).length > 0, "Farm name cannot be empty");
+		// require(bytes(_communityName).length > 0, "Community name cannot be empty");
+		UserRecord memory farmerRecordMemory = _userRecordsByAddress[
+			_farmOwner
+		];
+		require(
+			farmerRecordMemory.account != address(0),
+			"Farm owner is not a registered user"
+		);
+		require(
+			farmerRecordMemory.role == UserRole.FARMER,
+			"Only farmers can register as farm owners"
+		);
+		FarmRecord memory farmRecordMemory = _farmRecordsByOwner[_farmOwner];
+		require(
+			farmRecordMemory.farmOwner == address(0),
+			"Farm owner already has a registered farm"
+		);
+		require(
+			_farmRecordsByName[_farmName].farmOwner == address(0),
+			"Farm name already exists"
+		);
+		if (bytes(_communityName).length > 0) {
+			require(
+				communityRegistry.communitiesByName(_communityName).treasury !=
+					address(0),
+				"Community does not exist"
+			);
+		}
+		UserRecord memory senderUser = _userRecordsByAddress[msg.sender];
+		require(
+			msg.sender == _farmOwner || senderUser.role == UserRole.ADMIN,
+			"Only farm owner and admins can register farms"
+		);
+		uint communityId = communityRegistry
+			.communitiesByName(_communityName)
+			.id;
+		FarmRecord memory newFarm = FarmRecord({
+			farmName: _farmName,
+			farmOwner: _farmOwner,
+			description: _description,
+			location: _location,
+			imageUrl: _imageUrl,
+			socialAccounts: _socialAccounts,
+			communityId: communityId
+		});
+		_registerFarm(newFarm);
+		emit FarmRegistered(_farmName, _farmOwner, communityId);
+		return true;
+	}
 
-    function addUserToCommunity(address _newMember, string memory _communityName) external {
-        require(_newMember != address(0), "Invalid address");
-        require(userRecordsByAddress[_newMember].account != address(0), "User is not registered");
-        require(bytes(_communityName).length > 0, "Community name cannot be empty");
-        require(communitiesByName[_communityName].treasury != address(0), "Community does not exist");
-        if (userToCommunityIds[_newMember].length > 0) {
-            for (uint i; i < userToCommunityIds[_newMember].length; ++i) {
-                require(!Strings.equal(communities[userToCommunityIds[_newMember][i]].name, _communityName), "User already in community");
-            }
-        }
-        UserRecord memory newMember = userRecordsByAddress[_newMember];
-        if (newMember.role != UserRole.USER && newMember.role != UserRole.DONOR) {
-            require(msg.sender != newMember.account, "Farmers, managers and admins cannot add themselves");
-            UserRecord memory senderUser = userRecordsByAddress[msg.sender];
-            require(senderUser.role != UserRole.USER && senderUser.role != UserRole.DONOR, "Only farmers, managers and admins can add other farmers, managers and admins");
-        }
-        _addUserToCommunity(newMember, _communityName);
-        emit UserJoinedCommunity(newMember.account, _communityName, newMember.role);
-    }
+	// function registerCommunity(
+	//     string memory _name,
+	//     string memory _description,
+	//     string memory _location,
+	//     FarmRecord[] memory _farms
+	// ) external returns (address newTreasury) {
 
-    function removeUserFromCommunity(string memory _communityName, UserRole _role, uint256 index) external {
-        require(bytes(_communityName).length > 0, "Community name cannot be empty");
-        require(communitiesByName[_communityName].treasury != address(0), "Community does not exist");
-        UserRecord memory senderUser = userRecordsByAddress[msg.sender];
-        require(senderUser.role == UserRole.ADMIN, "Only admins can remove users from a community");
-        require(_role != UserRole.ADMIN, "Admins cannot be removed from a community");
-        require(index < communitiesByName[_communityName].membersByRole[_role].length, "Invalid index");
-        address userToRemove = communitiesByName[_communityName].membersByRole[_role][index].account;
-        delete communitiesByName[_communityName].membersByRole[_role][index];
-        for (uint i; i < userToCommunityIds[userToRemove].length; ++i) {
-            if (userToCommunityIds[userToRemove][i] == communitiesByName[_communityName].id) {
-                delete userToCommunityIds[userToRemove][i];
-                break;
-            }
-        }
-    }
+	// }
 
-    function addFarmProducts(ProductType[] memory _products) external onlyFarmOwner {
-        ProductType[] storage products = farmProductsByOwner[msg.sender];
-        for (uint i; i < _products.length; ++i) {
-            require(bytes(_products[i].name).length > 0, "Product name cannot be empty");
-            require(bytes(_products[i].unit).length > 0, "Product unit cannot be empty");
-            products.push(_products[i]);
-        }
-    }
+	// External registry management functions
 
-    function removeFarmProduct(uint index) external onlyFarmOwner {
-        ProductType[] storage products = farmProductsByOwner[msg.sender];
-        require(index < products.length, "Index out of bounds");
-        delete products[index];
-    }
+	function updateUserRecord(
+		string memory _newName,
+		string memory _newEmail,
+		string memory _newPhone,
+		string memory _newLocation
+	) external onlyUserAccount returns (UserRecord memory) {
+		require(bytes(_newName).length > 0, "Name cannot be empty");
+		require(bytes(_newEmail).length > 0, "Email cannot be empty");
+		UserRecord storage userRecord = _userRecordsByAddress[msg.sender];
+		string memory oldEmail = userRecord.email;
+		userRecord.name = _newName;
+		userRecord.email = _newEmail;
+		userRecord.phone = _newPhone;
+		userRecord.location = _newLocation;
+		if (!Strings.equal(oldEmail, _newEmail)) {
+			require(
+				_userRecordsByEmail[_newEmail].account == address(0),
+				"New email already registered"
+			);
+			delete _userRecordsByEmail[oldEmail];
+			_userRecordsByEmail[_newEmail] = userRecord;
+		}
+		return userRecord;
+	}
 
-    // Internal functions
+	function updateFarmRecord(
+		string memory _newDescription,
+		string memory _newLocation,
+		string memory _newImageUrl,
+		string[] memory _newSocialAccounts
+	) external onlyFarmOwner returns (FarmRecord memory) {
+		FarmRecord storage farmRecord = _farmRecordsByOwner[msg.sender];
+		farmRecord.description = _newDescription;
+		farmRecord.location = _newLocation;
+		farmRecord.imageUrl = _newImageUrl;
+		farmRecord.socialAccounts = _newSocialAccounts;
+		return farmRecord;
+	}
 
-    function _registerUser(UserRecord memory _userRecord) internal {
-        userRecordsByAddress[_userRecord.account] = _userRecord;
-        userRecordsByEmail[_userRecord.email] = _userRecord;
-    }
+	function addFarmProducts(
+		ProductType[] memory _products
+	) external onlyFarmOwner {
+		ProductType[] storage products = _farmProductsByOwner[msg.sender];
+		for (uint i; i < _products.length; ++i) {
+			require(
+				bytes(_products[i].name).length > 0,
+				"Product name cannot be empty"
+			);
+			require(
+				bytes(_products[i].unit).length > 0,
+				"Product unit cannot be empty"
+			);
+			products.push(_products[i]);
+		}
+	}
 
-    function _registerFarm(FarmRecord memory _farmRecord) internal {
-        farmRecordsByOwner[_farmRecord.farmOwner] = _farmRecord;
-        farmRecordsByName[_farmRecord.farmName] = _farmRecord;
-        communitiesById[_farmRecord.communityId].farms.push(_farmRecord);
-    }
+	function removeFarmProduct(uint index) external onlyFarmOwner {
+		ProductType[] storage products = _farmProductsByOwner[msg.sender];
+		require(index < products.length, "Index out of bounds");
+		delete products[index];
+	}
 
-    function _addUserToCommunity(UserRecord memory _newUser, string memory _communityName) internal {
-        require(communitiesByName[_communityName].treasury != address(0), "Community does not exist");
-        userToCommunityIds[msg.sender].push(communitiesByName[_communityName].id);
-        communitiesByName[_communityName].membersByRole[_newUser.role].push(_newUser);
-    }
+	// External admin functions
+
+	function setCommunityRegistry(
+		address _communityRegistry
+	) external onlyOwner {
+		communityRegistry = ICommunityRegistry(_communityRegistry);
+	}
+
+	// Internal functions
+
+	function _registerUser(UserRecord memory _userRecord) internal {
+		_userRecordsByAddress[_userRecord.account] = _userRecord;
+		_userRecordsByEmail[_userRecord.email] = _userRecord;
+	}
+
+	function _registerFarm(FarmRecord memory _farmRecord) internal {
+		_farmRecordsByOwner[_farmRecord.farmOwner] = _farmRecord;
+		_farmRecordsByName[_farmRecord.farmName] = _farmRecord;
+		// communitiesById[_farmRecord.communityId].farms.push(_farmRecord);
+	}
 
 }

--- a/packages/hardhat/contracts/UserRegistry.sol
+++ b/packages/hardhat/contracts/UserRegistry.sol
@@ -101,7 +101,7 @@ contract UserRegistry is IUserRegistry, Ownable {
 		}
 		emit UserRegistered(newUser.account, newUser.email, newUser.role);
 		if(bytes(_communityName).length > 0) {
-		    communityRegistry.addUserToCommunity(newUser.account, _communityName);
+		    communityRegistry.addUserToCommunity(newUser.account, communityRegistry.communityIdByName(_communityName));
 		}
 		return true;
 	}
@@ -153,7 +153,7 @@ contract UserRegistry is IUserRegistry, Ownable {
 		_registerUser(newUser);
 		emit UserRegistered(newUser.account, newUser.email, newUser.role);
 		if(bytes(_communityName).length > 0) {
-		    communityRegistry.addUserToCommunity(newUser.account, _communityName);
+		    communityRegistry.addUserToCommunity(newUser.account, communityRegistry.communityIdByName(_communityName));
 		}
 		return true;
 	}

--- a/packages/hardhat/contracts/UserRegistry.sol
+++ b/packages/hardhat/contracts/UserRegistry.sol
@@ -189,13 +189,6 @@ contract UserRegistry is IUserRegistry, Ownable {
 			_farmOwnerByFarmName[_farmName] == address(0),
 			"Farm name already exists"
 		);
-		if (bytes(_communityName).length > 0) {
-			require(
-				communityRegistry.communitiesByName(_communityName).treasury !=
-					address(0),
-				"Community does not exist"
-			);
-		}
 		UserRecord memory senderUser = _userRecordsByAddress[msg.sender];
 		require(
 			msg.sender == _farmOwner || senderUser.role == UserRole.ADMIN,
@@ -214,6 +207,14 @@ contract UserRegistry is IUserRegistry, Ownable {
 			communityId: communityId
 		});
 		_registerFarm(newFarm);
+        if (bytes(_communityName).length > 0) {
+			require(
+				communityRegistry.communitiesByName(_communityName).treasury !=
+					address(0),
+				"Community does not exist"
+			);
+            communityRegistry.addFarmToCommunity(_farmOwner, communityId);
+		}
 		emit FarmRegistered(_farmName, _farmOwner, communityId);
 		return true;
 	}

--- a/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
@@ -18,14 +18,22 @@ interface ICommunityRegistry {
     function communityToDonors(uint _communityId) external view returns (UserRecord[] memory);
     function communityToManagers(uint _communityId) external view returns (UserRecord[] memory);
     function communityToFarmers(uint _communityId) external view returns (UserRecord[] memory);
+    function communityToFarms(uint _communityId) external view returns (FarmRecord[] memory);
+
+    function registerCommunity(
+		string memory _name,
+		string memory _description,
+		string memory _location,
+		address[] memory _initialOwners
+	) external returns (address payable newTreasury);
 
     function addUserToCommunity(
 		address _newMember,
-		string memory _communityName
+		uint _communityId
 	) external;
 
     function removeUserFromCommunity(
-		string memory _communityName,
+		uint _communityId,
 		UserRole _role,
 		uint256 index
 	) external;

--- a/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
@@ -1,0 +1,30 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../Common.sol";
+
+
+interface ICommunityRegistry {
+
+    event CommunityRegistered(string name, string location, address creator, address treasury);
+    event UserJoinedCommunity(address user, string communityName, UserRole role);
+    event UserRemovedFromCommunity(address user, string communityName);
+
+    function communitiesByName(string memory _name) external returns (Community memory);
+    function communitiesById(uint _id) external returns (Community memory);
+    function communityIdByName(string memory _name) external view returns (uint);
+    function userToCommunityIds(address _user) external view returns (uint[] memory);
+
+    function addUserToCommunity(
+		address _newMember,
+		string memory _communityName
+	) external;
+
+    function removeUserFromCommunity(
+		string memory _communityName,
+		UserRole _role,
+		uint256 index
+	) external;
+
+    function setUserRegistry(address _userRegistry) external;
+}

--- a/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
@@ -14,6 +14,10 @@ interface ICommunityRegistry {
     function communitiesById(uint _id) external returns (Community memory);
     function communityIdByName(string memory _name) external view returns (uint);
     function userToCommunityIds(address _user) external view returns (uint[] memory);
+    function communityToUsers(uint _communityId) external view returns (UserRecord[] memory);
+    function communityToDonors(uint _communityId) external view returns (UserRecord[] memory);
+    function communityToManagers(uint _communityId) external view returns (UserRecord[] memory);
+    function communityToFarmers(uint _communityId) external view returns (UserRecord[] memory);
 
     function addUserToCommunity(
 		address _newMember,

--- a/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
@@ -9,6 +9,7 @@ interface ICommunityRegistry {
     event CommunityRegistered(string name, string location, address creator, address treasury);
     event UserJoinedCommunity(address user, string communityName, UserRole role);
     event UserRemovedFromCommunity(address user, string communityName);
+    event FarmJoinedCommunity(address farmOwner, string farmName, string communityName);
 
     function communitiesByName(string memory _name) external returns (Community memory);
     function communitiesById(uint _id) external returns (Community memory);
@@ -37,6 +38,11 @@ interface ICommunityRegistry {
 		UserRole _role,
 		uint256 index
 	) external;
+
+    function addFarmToCommunity(
+        address _farmOwner,
+        uint _communityId
+    ) external;
 
     function setUserRegistry(address _userRegistry) external;
 }

--- a/packages/hardhat/contracts/interfaces/IUserRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/IUserRegistry.sol
@@ -5,6 +5,7 @@ import "../Common.sol";
 
 interface IUserRegistry {
     event UserRegistered(address account, string email, UserRole role);
+    event UserPendingApproval(address account, string email, UserRole role);
     event FarmRegistered(string farmName, address farmOwner, uint communityId);
 
     function userRecordByAddress(address _address) external view returns (UserRecord memory);
@@ -30,6 +31,8 @@ interface IUserRegistry {
         UserRole _role,
         string memory _communityName
     ) external returns (bool);
+
+    function approvePendingUser(uint index) external;
 
     function registerFarm(
         address _farmOwner,

--- a/packages/hardhat/contracts/interfaces/IUserRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/IUserRegistry.sol
@@ -1,0 +1,91 @@
+//SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../Common.sol";
+
+interface IUserRegistry {
+    enum UserRole {
+        ADMIN,
+        FARMER,
+        MANAGER,
+        USER,
+        DONOR
+    }
+
+    struct UserRecord {
+        address account;
+        string name;
+        string email;
+        string phone;
+        string location;
+        UserRole role;
+    }
+
+    struct FarmRecord {
+        string farmName;
+        address farmOwner;
+        string description;
+        string location;
+        string imageUrl;
+        string[] socialAccounts;
+    }
+
+    struct Community {
+        string name;
+        string description;
+        string location;
+        address treasury;
+        UserRecord[] users;
+        UserRecord[] farmers;
+        UserRecord[] managers;
+        UserRecord[] donors;
+        FarmRecord[] farms;
+    }
+
+    event UserRegistered(address account, string email, UserRole role);
+    event FarmRegistered(string farmName, address farmOwner);
+
+    function registerUserSelf(
+        string memory _name, 
+        string memory _email,
+        string memory _phone,
+        string memory _location,
+        UserRole _role
+    ) external returns (bool);
+
+    function registerUserOnBehalfOf(
+        address _userAddress,
+        string memory _name,
+        string memory _email,
+        string memory _phone,
+        string memory _location,
+        UserRole _role
+    ) external returns (bool);
+
+    function registerFarm(
+        address _farmOwner,
+        string memory _farmName,
+        string memory _description,
+        string memory _location,
+        string memory _imageUrl,
+        string[] memory _socialAccounts
+    ) external returns (bool);
+
+    function updateUserRecord(
+        string memory _newName,
+        string memory _newEmail,
+        string memory _newPhone,
+        string memory _newLocation
+    ) external returns (UserRecord memory);
+
+    function updateFarmRecord(
+        string memory _newDescription,
+        string memory _newLocation,
+        string memory _newImageUrl,
+        string[] memory _newSocialAccounts
+    ) external returns (FarmRecord memory);
+
+    function addFarmProducts(ProductType[] memory _products) external;
+
+    function removeFarmProduct(uint index) external;
+}

--- a/packages/hardhat/contracts/interfaces/IUserRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/IUserRegistry.sol
@@ -55,8 +55,5 @@ interface IUserRegistry {
         string[] memory _newSocialAccounts
     ) external returns (FarmRecord memory);
 
-    function addFarmProducts(ProductType[] memory _products) external;
-    function removeFarmProduct(uint index) external;
-
     function setCommunityRegistry(address _communityRegistry) external;
 }

--- a/packages/hardhat/contracts/interfaces/IUserRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/IUserRegistry.sol
@@ -4,49 +4,14 @@ pragma solidity ^0.8.0;
 import "../Common.sol";
 
 interface IUserRegistry {
-    enum UserRole {
-        USER,
-        DONOR,
-        MANAGER,
-        FARMER,
-        ADMIN
-    }
-
-    struct UserRecord {
-        address account;
-        string name;
-        string email;
-        string phone;
-        string location;
-        UserRole role;
-    }
-
-    struct FarmRecord {
-        string farmName;
-        address farmOwner;
-        string description;
-        string location;
-        string imageUrl;
-        string[] socialAccounts;
-        uint communityId;
-    }
-
-    struct Community {
-        uint id;
-        string name;
-        string description;
-        string location;
-        address treasury;
-        mapping(UserRole => UserRecord[]) membersByRole;
-        FarmRecord[] farms;
-    }
-
     event UserRegistered(address account, string email, UserRole role);
     event FarmRegistered(string farmName, address farmOwner, uint communityId);
-    event CommunityRegistered(string name, string location, address creator, address treasury);
-    event UserJoinedCommunity(address user, string communityName, UserRole role);
-    event UserRemovedFromCommunity(address user, string communityName);
 
+    function userRecordByAddress(address _address) external view returns (UserRecord memory);
+    function userRecordByEmail(string memory _email) external view returns (UserRecord memory);
+    function farmRecordByOwner(address _owner) external view returns (FarmRecord memory);
+    function farmRecordByName(string memory _name) external view returns (FarmRecord memory);
+    
     function registerUserSelf(
         string memory _name, 
         string memory _email,
@@ -90,11 +55,8 @@ interface IUserRegistry {
         string[] memory _newSocialAccounts
     ) external returns (FarmRecord memory);
 
-    function addUserToCommunity(address _newMember, string memory _communityName) external;
-
-    function removeUserFromCommunity(string memory _communityName, UserRole _role, uint256 index) external;
-
     function addFarmProducts(ProductType[] memory _products) external;
-
     function removeFarmProduct(uint index) external;
+
+    function setCommunityRegistry(address _communityRegistry) external;
 }

--- a/packages/hardhat/contracts/interfaces/IUserRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/IUserRegistry.sol
@@ -5,11 +5,11 @@ import "../Common.sol";
 
 interface IUserRegistry {
     enum UserRole {
-        ADMIN,
-        FARMER,
-        MANAGER,
         USER,
-        DONOR
+        DONOR,
+        MANAGER,
+        FARMER,
+        ADMIN
     }
 
     struct UserRecord {
@@ -28,29 +28,32 @@ interface IUserRegistry {
         string location;
         string imageUrl;
         string[] socialAccounts;
+        uint communityId;
     }
 
     struct Community {
+        uint id;
         string name;
         string description;
         string location;
         address treasury;
-        UserRecord[] users;
-        UserRecord[] farmers;
-        UserRecord[] managers;
-        UserRecord[] donors;
+        mapping(UserRole => UserRecord[]) membersByRole;
         FarmRecord[] farms;
     }
 
     event UserRegistered(address account, string email, UserRole role);
-    event FarmRegistered(string farmName, address farmOwner);
+    event FarmRegistered(string farmName, address farmOwner, uint communityId);
+    event CommunityRegistered(string name, string location, address creator, address treasury);
+    event UserJoinedCommunity(address user, string communityName, UserRole role);
+    event UserRemovedFromCommunity(address user, string communityName);
 
     function registerUserSelf(
         string memory _name, 
         string memory _email,
         string memory _phone,
         string memory _location,
-        UserRole _role
+        UserRole _role,
+        string memory _communityName
     ) external returns (bool);
 
     function registerUserOnBehalfOf(
@@ -59,7 +62,8 @@ interface IUserRegistry {
         string memory _email,
         string memory _phone,
         string memory _location,
-        UserRole _role
+        UserRole _role,
+        string memory _communityName
     ) external returns (bool);
 
     function registerFarm(
@@ -68,7 +72,8 @@ interface IUserRegistry {
         string memory _description,
         string memory _location,
         string memory _imageUrl,
-        string[] memory _socialAccounts
+        string[] memory _socialAccounts,
+        string memory _communityName
     ) external returns (bool);
 
     function updateUserRecord(
@@ -84,6 +89,10 @@ interface IUserRegistry {
         string memory _newImageUrl,
         string[] memory _newSocialAccounts
     ) external returns (FarmRecord memory);
+
+    function addUserToCommunity(address _newMember, string memory _communityName) external;
+
+    function removeUserFromCommunity(string memory _communityName, UserRole _role, uint256 index) external;
 
     function addFarmProducts(ProductType[] memory _products) external;
 

--- a/packages/hardhat/deploy/00_deploy_safe_contracts.ts
+++ b/packages/hardhat/deploy/00_deploy_safe_contracts.ts
@@ -1,0 +1,32 @@
+import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+
+const deploy: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+    const { deployments, getNamedAccounts } = hre;
+    const { deployer } = await getNamedAccounts();
+    const { deploy } = deployments;
+
+    await deploy("SafeProxyFactory", {
+        from: deployer,
+        args: [],
+        log: true,
+        deterministicDeployment: true,
+    });
+
+    await deploy("Safe", {
+        from: deployer,
+        args: [],
+        log: true,
+        deterministicDeployment: true,
+    });
+
+    await deploy("CompatibilityFallbackHandler", {
+        from: deployer,
+        args: [],
+        log: true,
+        deterministicDeployment: true,
+    });
+};
+
+deploy.tags = ["safe"];
+export default deploy;

--- a/packages/hardhat/deploy/01_deploy_registry_contracts.ts
+++ b/packages/hardhat/deploy/01_deploy_registry_contracts.ts
@@ -1,6 +1,5 @@
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { DeployFunction } from "hardhat-deploy/types";
-// import { ethers, upgrades } from "hardhat";
 
 /**
  * Deploys a contract named "UserRegistry" using the deployer account
@@ -31,10 +30,14 @@ const deployRegistryContracts: DeployFunction = async function (hre: HardhatRunt
     autoMine: true,
   });
 
+  const safeProxyFactory = await hre.ethers.getContract("SafeProxyFactory");
+  const safeSingleton = await hre.ethers.getContract("Safe");
+  const safeFallbackHandler = await hre.ethers.getContract("CompatibilityFallbackHandler");
+
   await deploy("CommunityRegistry", {
     from: deployer,
     // Contract constructor arguments
-    args: [],
+    args: [safeProxyFactory.address, safeSingleton.address, safeFallbackHandler.address],
     log: true,
     // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
     // automatically mining the contract deployment transaction. There is no effect on live networks.
@@ -53,5 +56,5 @@ const deployRegistryContracts: DeployFunction = async function (hre: HardhatRunt
 export default deployRegistryContracts;
 
 // Tags are useful if you have multiple deploy files and only want to run one of them.
-// e.g. yarn deploy --tags YourContract
-deployRegistryContracts.tags = ["UserRegistry"];
+// e.g. yarn deploy --tags RegistryContracts
+deployRegistryContracts.tags = ["RegistryContracts"];

--- a/packages/hardhat/deploy/01_deploy_registry_contracts.ts
+++ b/packages/hardhat/deploy/01_deploy_registry_contracts.ts
@@ -7,7 +7,7 @@ import { DeployFunction } from "hardhat-deploy/types";
  *
  * @param hre HardhatRuntimeEnvironment object.
  */
-const deployUserRegistry: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+const deployRegistryContracts: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   /*
     On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
 
@@ -31,12 +31,27 @@ const deployUserRegistry: DeployFunction = async function (hre: HardhatRuntimeEn
     autoMine: true,
   });
 
-  // Get the deployed contract
-  // const yourContract = await hre.ethers.getContract("YourContract", deployer);
+  await deploy("CommunityRegistry", {
+    from: deployer,
+    // Contract constructor arguments
+    args: [],
+    log: true,
+    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
+    // automatically mining the contract deployment transaction. There is no effect on live networks.
+    autoMine: true,
+  });
+
+  // Get the deployed contracts
+  const userRegistry = await hre.ethers.getContract("UserRegistry", deployer);
+  const communityRegistry = await hre.ethers.getContract("CommunityRegistry", deployer);
+
+  // Set up links between registry contracts
+  await userRegistry.setCommunityRegistry(communityRegistry.address);
+  await communityRegistry.setUserRegistry(userRegistry.address);
 };
 
-export default deployUserRegistry;
+export default deployRegistryContracts;
 
 // Tags are useful if you have multiple deploy files and only want to run one of them.
 // e.g. yarn deploy --tags YourContract
-deployUserRegistry.tags = ["UserRegistry"];
+deployRegistryContracts.tags = ["UserRegistry"];

--- a/packages/hardhat/deploy/01_deploy_user_registry.ts
+++ b/packages/hardhat/deploy/01_deploy_user_registry.ts
@@ -1,0 +1,42 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { DeployFunction } from "hardhat-deploy/types";
+// import { ethers, upgrades } from "hardhat";
+
+/**
+ * Deploys a contract named "UserRegistry" using the deployer account
+ *
+ * @param hre HardhatRuntimeEnvironment object.
+ */
+const deployUserRegistry: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  /*
+    On localhost, the deployer account is the one that comes with Hardhat, which is already funded.
+
+    When deploying to live networks (e.g `yarn deploy --network goerli`), the deployer account
+    should have sufficient balance to pay for the gas fees for contract creation.
+
+    You can generate a random account with `yarn generate` which will fill DEPLOYER_PRIVATE_KEY
+    with a random private key in the .env file (then used on hardhat.config.ts)
+    You can run the `yarn account` command to check your balance in every network.
+  */
+  const { deployer } = await hre.getNamedAccounts();
+  const { deploy } = hre.deployments;
+
+  await deploy("UserRegistry", {
+    from: deployer,
+    // Contract constructor arguments
+    args: [],
+    log: true,
+    // autoMine: can be passed to the deploy function to make the deployment process faster on local networks by
+    // automatically mining the contract deployment transaction. There is no effect on live networks.
+    autoMine: true,
+  });
+
+  // Get the deployed contract
+  // const yourContract = await hre.ethers.getContract("YourContract", deployer);
+};
+
+export default deployUserRegistry;
+
+// Tags are useful if you have multiple deploy files and only want to run one of them.
+// e.g. yarn deploy --tags YourContract
+deployUserRegistry.tags = ["UserRegistry"];

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -46,7 +46,8 @@
     "typescript": "^4.9.5"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.8.1",
+    "@ethereum-attestation-service/eas-contracts": "^1.0.0-beta.0",
+    "@openzeppelin/contracts": "^4.9.2",
     "dotenv": "^16.0.3",
     "envfile": "^6.18.0",
     "qrcode": "^1.5.1"

--- a/packages/hardhat/package.json
+++ b/packages/hardhat/package.json
@@ -47,7 +47,9 @@
   },
   "dependencies": {
     "@ethereum-attestation-service/eas-contracts": "^1.0.0-beta.0",
+    "@matterlabs/zksync-contracts": "^0.6.1",
     "@openzeppelin/contracts": "^4.9.2",
+    "@safe-global/safe-contracts": "^1.4.1-build.0",
     "dotenv": "^16.0.3",
     "envfile": "^6.18.0",
     "qrcode": "^1.5.1"

--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -12,7 +12,7 @@ export type ScaffoldConfig = {
 
 const scaffoldConfig = {
   // The network where your DApp lives in
-  targetNetwork: chains.xdc,
+  targetNetwork: chains.hardhat,
 
   // The interval at which your front-end polls the RPC servers for new data
   // it has no effect on the local network

--- a/yarn.lock
+++ b/yarn.lock
@@ -2112,6 +2112,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ethereum-attestation-service/eas-contracts@npm:^1.0.0-beta.0":
+  version: 1.0.0-beta.0
+  resolution: "@ethereum-attestation-service/eas-contracts@npm:1.0.0-beta.0"
+  dependencies:
+    hardhat: 2.17.0
+  checksum: c01087d1919bd96f63d759d6bfd8de890263d0ec373f312a3ab42f73f2d7e276d64ae1fa1efec9bf6b49ebd4ee6c7ee6663b78582fbdda206c8b69c67a6faf36
+  languageName: node
+  linkType: hard
+
 "@ethereumjs/common@npm:^2.4.0":
   version: 2.6.5
   resolution: "@ethereumjs/common@npm:2.6.5"
@@ -3501,7 +3510,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^4.8.1":
+"@openzeppelin/contracts@npm:^4.9.2":
   version: 4.9.2
   resolution: "@openzeppelin/contracts@npm:4.9.2"
   checksum: 0538b18fe222e5414a5a539c240b155e0bef2a23c5182fb8e137d71a0c390fe899160f2d55701f75b127f54cc61aee4375370acc832475f19829368ac65c1fc6
@@ -3758,6 +3767,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@se-2/hardhat@workspace:packages/hardhat"
   dependencies:
+    "@ethereum-attestation-service/eas-contracts": ^1.0.0-beta.0
     "@ethersproject/abi": ^5.7.0
     "@ethersproject/providers": ^5.7.1
     "@matterlabs/hardhat-zksync-solc": ^0.3.17
@@ -3767,7 +3777,7 @@ __metadata:
     "@nomicfoundation/hardhat-toolbox": ^2.0.0
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13"
     "@nomiclabs/hardhat-etherscan": ^3.1.0
-    "@openzeppelin/contracts": ^4.8.1
+    "@openzeppelin/contracts": ^4.9.2
     "@typechain/ethers-v5": ^10.1.0
     "@typechain/hardhat": ^6.1.3
     "@types/eslint": ^8
@@ -11795,7 +11805,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:^2.11.2":
+"hardhat@npm:2.17.0, hardhat@npm:^2.11.2":
   version: 2.17.0
   resolution: "hardhat@npm:2.17.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2795,6 +2795,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@matterlabs/zksync-contracts@npm:^0.6.1":
+  version: 0.6.1
+  resolution: "@matterlabs/zksync-contracts@npm:0.6.1"
+  peerDependencies:
+    "@openzeppelin/contracts": 4.6.0
+    "@openzeppelin/contracts-upgradeable": 4.6.0
+  checksum: 736215697fb7529de2bfbb1d73f2a2656d4d048cd2b6fa46e67deceb6c0cbe7ceebc1c6dcb762c7522f527f7bfcd335bf4421061e85d9779c36602f967da4f25
+  languageName: node
+  linkType: hard
+
 "@metamask/detect-provider@npm:^2.0.0":
   version: 2.0.0
   resolution: "@metamask/detect-provider@npm:2.0.0"
@@ -3684,6 +3694,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@safe-global/safe-contracts@npm:^1.4.1-build.0":
+  version: 1.4.1
+  resolution: "@safe-global/safe-contracts@npm:1.4.1"
+  peerDependencies:
+    ethers: 5.4.0
+  checksum: 480676f29270ca2c81580968ed4faee3a92d057bcb4e6fa7af5d0420e020af0f85dafc44a56eed11121dd6beae4866f1b15ff0a1a7a2483d2b3a876b9323c79e
+  languageName: node
+  linkType: hard
+
 "@safe-global/safe-gateway-typescript-sdk@npm:^3.5.3":
   version: 3.7.3
   resolution: "@safe-global/safe-gateway-typescript-sdk@npm:3.7.3"
@@ -3772,12 +3791,14 @@ __metadata:
     "@ethersproject/providers": ^5.7.1
     "@matterlabs/hardhat-zksync-solc": ^0.3.17
     "@matterlabs/hardhat-zksync-verify": ^0.1.8
+    "@matterlabs/zksync-contracts": ^0.6.1
     "@nomicfoundation/hardhat-chai-matchers": ^1.0.3
     "@nomicfoundation/hardhat-network-helpers": ^1.0.6
     "@nomicfoundation/hardhat-toolbox": ^2.0.0
     "@nomiclabs/hardhat-ethers": "npm:hardhat-deploy-ethers@^0.3.0-beta.13"
     "@nomiclabs/hardhat-etherscan": ^3.1.0
     "@openzeppelin/contracts": ^4.9.2
+    "@safe-global/safe-contracts": ^1.4.1-build.0
     "@typechain/ethers-v5": ^10.1.0
     "@typechain/hardhat": ^6.1.3
     "@types/eslint": ^8


### PR DESCRIPTION
Adds the first set of contracts, to be used for onboarding.

- UserRegistry.sol / IUserRegistry.sol
    - Stores records for users and farms
    - Has mappings / view functions for accessing user/farm records
    - Has mappings for storing lists of attestations per user (not used yet)
    - Has functions for registering and for updating records
- CommunityRegistry.sol / ICommunityRegistry.sol
    - Stores records for communities
    - Has mappings / view functions for accessing community records
    - Has mappings / view functions for accessing lists of community members by role
    - Has functions for adding and removing users to or from a community
    - Has a function for creating a new community, which also deploys a Safe (proxy) multisig treasury
- Common.sol 
    - Declares enums and structs used by the registry contracts (and other contracts to be developed)
        - `UserRole`: can be a user, donor, manager, farmer or admin
        - `TaskStatus`: can be to-do, in--progress or complete (not used yet)
        - `UserRecord`: stores an account address, name, email, phone, location and role
        - `FarmRecord`: stores a farm name, owner address, description, location, image url, social accounts, and community ID
        - `Community`: stores a community ID, name, description, location, treasury address and list of farm records
        - `ProductType`: stores a name, unit, description and image url (not used yet)
        - `Task`: stores a task ID, name, description, creator address, deadline timestamp, reward amount, status and list of attestation IDs