### PR TITLE
Remove duplicate struct storage

### DIFF
--- a/packages/hardhat/contracts/Common.sol
+++ b/packages/hardhat/contracts/Common.sol
@@ -40,7 +40,6 @@ struct Community {
     string description;
     string location;
     address payable treasury;
-    FarmRecord[] farms;
 }
 
 struct ProductType {

--- a/packages/hardhat/contracts/UserRegistry.sol
+++ b/packages/hardhat/contracts/UserRegistry.sol
@@ -101,7 +101,7 @@ contract UserRegistry is IUserRegistry, Ownable {
 		}
 		emit UserRegistered(newUser.account, newUser.email, newUser.role);
 		if(bytes(_communityName).length > 0) {
-		    communityRegistry.addUserToCommunity(newUser.account, _communityName);
+		    communityRegistry.addUserToCommunity(newUser.account, communityRegistry.communityIdByName(_communityName));
 		}
 		return true;
 	}
@@ -153,7 +153,7 @@ contract UserRegistry is IUserRegistry, Ownable {
 		_registerUser(newUser);
 		emit UserRegistered(newUser.account, newUser.email, newUser.role);
 		if(bytes(_communityName).length > 0) {
-		    communityRegistry.addUserToCommunity(newUser.account, _communityName);
+		    communityRegistry.addUserToCommunity(newUser.account, communityRegistry.communityIdByName(_communityName));
 		}
 		return true;
 	}

--- a/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
+++ b/packages/hardhat/contracts/interfaces/ICommunityRegistry.sol
@@ -18,14 +18,22 @@ interface ICommunityRegistry {
     function communityToDonors(uint _communityId) external view returns (UserRecord[] memory);
     function communityToManagers(uint _communityId) external view returns (UserRecord[] memory);
     function communityToFarmers(uint _communityId) external view returns (UserRecord[] memory);
+    function communityToFarms(uint _communityId) external view returns (FarmRecord[] memory);
+
+    function registerCommunity(
+		string memory _name,
+		string memory _description,
+		string memory _location,
+		address[] memory _initialOwners
+	) external returns (address payable newTreasury);
 
     function addUserToCommunity(
 		address _newMember,
-		string memory _communityName
+		uint _communityId
 	) external;
 
     function removeUserFromCommunity(
-		string memory _communityName,
+		uint _communityId,
 		UserRole _role,
 		uint256 index
 	) external;


### PR DESCRIPTION
Using two mappings like
```solidity
mapping(address => UserRecord) private _userRecordsByAddress;
mapping(string => UserRecord) private _userRecordsByEmail;
```
was duplicating the storage of these structs, meaning to update a record you had to change the values twice.
Instead, we can do the following
```solidity
mapping(address => UserRecord) private _userRecordsByAddress;
mapping(string => address) private _userAddressByEmail;
```
And to easily fetch a UserRecord by email, just do
```solidity
    function userRecordByEmail(
        string memory _email
    ) external view override returns (UserRecord memory) {
        return _userRecordsByAddress[_userAddressByEmail[_email]];
    }
```